### PR TITLE
Исключить дублирующий код в методах move_unit

### DIFF
--- a/field.py
+++ b/field.py
@@ -6,35 +6,28 @@ class Field:
     def cell(self, coord):  # метод, возвращающий объект находящийся по данным координатам;
         x, y = coord
         return self.field_array[y][x]
-
-    def move_unit_up(self):  # метод, смещающий юнита вверх;
-        x, y = self.unit.get_coordinates()
-        step_on_obj = self.cell((x, y - 1)).get_obj()
+    
+    def _do_move(self, x, y):
+       step_on_obj = self.cell((x, y)).get_obj()
         step_on_obj.step_on(self.unit)
         if step_on_obj.is_walkable():
-            self.unit.set_coordinates((x, y - 1))
+            self.unit.set_coordinates((x, y))
+    
+    def move_unit_up(self):  # метод, смещающий юнита вверх;
+        x, y = self.unit.get_coordinates()
+        self._do_move(x, y-1)
 
     def move_unit_down(self):  # метод, смещающий юнита вниз;
         x, y = self.unit.get_coordinates()
-        step_on_obj = self.cell((x, y + 1)).get_obj()
-        step_on_obj.step_on(self.unit)
-        if step_on_obj.is_walkable():
-            self.unit.set_coordinates((x, y + 1))
+        self._do_move(x, y+1)
 
     def move_unit_right(self):  # метод, смещающий юнита вправо;
         x, y = self.unit.get_coordinates()
-        step_on_obj = self.cell((x + 1, y)).get_obj()
-        step_on_obj.step_on(self.unit)
-        if step_on_obj.is_walkable():
-            self.unit.set_coordinates((x + 1, y))
+        self._do_move(x+1, y)
 
     def move_unit_left(self):  # метод, смещающий юнита влево;
         x, y = self.unit.get_coordinates()
-        step_on_obj = self.cell((x - 1, y)).get_obj()
-        step_on_obj.step_on(self.unit)
-        if step_on_obj.is_walkable():
-            self.unit.set_coordinates((x - 1, y))
-
+        self._do_move(x-1, y)
 
     def get_field(self):  # возвращает свойство field.
         return self.field_array


### PR DESCRIPTION
Код в фунциях move_unit_up, move_unit_dow, move_unit_left, move_unit_right повторяется почти один в один. Можно изменять координаты в начале метода, а дельнейший код вынести во вспомогательный метод.